### PR TITLE
Add Dockerfile for Redis and update docker-compose.yaml

### DIFF
--- a/Dockerfile.redis
+++ b/Dockerfile.redis
@@ -1,0 +1,5 @@
+FROM redis:6.2-alpine
+
+COPY ./redis.conf /etc/redis/redis.conf
+
+ENTRYPOINT [ "redis-server", "/etc/redis/redis.conf" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,13 +10,13 @@ services:
     networks:
       - kfet-network
   cache:
-    image: redis:6.2-alpine
+    build:
+      context: .
+      dockerfile: Dockerfile.redis
     restart: always
     volumes: 
       - redis-socket:/var/run/redis
-      - ./redis.conf:/etc/redis/redis.conf
       - cache:/data
-    command: ["/bin/sh", "-c",  "chown -R redis /var/run/redis/ && redis-server /etc/redis/redis.conf"]
   app:
     container_name: kfet-app
     build:


### PR DESCRIPTION
La connection au service redis ne s'effectuait pas car le fichier de configuration n'étais pas passé en copy au moment du build mais par bind mount pendant le cycle de vie du container (où le fichier n'était pas disponible)
Ce merge vise à fix ça