### PR TITLE
Ajout d'un .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = lf
+
+[{*.ts,*.tsx,docker-compose*,*.config.js}]
+indent_size = 2
+
+[{package.json,tsconfig.json,.eslintrc.json,globals.css}]
+indent_size = 2
+
+[{prisma/migrations/*.sql}]
+indent_size = unset


### PR DESCRIPTION
- Ajout de .editorconfig pour assurer une mise en forme cohérente entre les différents éditeurs.
- Permet d'appliquer des règles de style principales telles que la taille de l'indentation, les fins de ligne et la présence d'une ligne ou non en fin de fichier.
- Améliore les review en réduisant les diff et en évitant les changements inutiles.