### PR TITLE
Add .dockerignore file to exclude unnecessary files from Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# This file specifies which files and directories should be ignored by Docker when building the image.
+node_modules
+.env
+*.log
+dist
+build
+coverage
+*.tsbuildinfo
+.DS_Store
+npm-debug.log
+yarn-error.log

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,5 +7,3 @@ build
 coverage
 *.tsbuildinfo
 .DS_Store
-npm-debug.log
-yarn-error.log


### PR DESCRIPTION
```
> [app 5/5] RUN npm run build:
0.999 This information is used to shape Next.js' roadmap and prioritize features.
0.999 You can learn more, including how to opt-out if you'd not like to participate in this anonymous program, by visiting the following URL:
0.999 https://nextjs.org/telemetry
0.999
1.015 Browserslist: caniuse-lite is outdated. Please run:
1.015   npx browserslist@latest --update-db
1.015   Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
1.054 info  - Checking validity of types...
8.163 info  - Creating an optimized production build...
8.974 Illegal instruction (core dumped)
------
failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 132
exit status 1
Oops something is not okay, are you okay? 😢
failed to solve: process "/bin/sh -c npm run build" did not complete successfully: exit code: 132
exit status 1
```

Après recherche, ça pourrait être dû au fait que pour une certaine raison, au moment du build, il détecte un node modules, qu'il copie dedans, et certains fichiers du node module n'auraient pas la même archi (arm, x86...) 
Pour s'assurer qu'il ne prenne pas les mauvais fichiers au moment du build, on ajoute au docker ignore